### PR TITLE
Add JWT authentication

### DIFF
--- a/ControleFinanceiro.Api/ControleFinanceiro.Api.csproj
+++ b/ControleFinanceiro.Api/ControleFinanceiro.Api.csproj
@@ -6,5 +6,6 @@
     <ProjectReference Include="..\ControleFinanceiro.Application\ControleFinanceiro.Application.csproj" />
     <ProjectReference Include="..\ControleFinanceiro.Domain\ControleFinanceiro.Domain.csproj" />
     <ProjectReference Include="..\ControleFinanceiro.Infrastructure\ControleFinanceiro.Infrastructure.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/ControleFinanceiro.Api/Controllers/AuthController.cs
+++ b/ControleFinanceiro.Api/Controllers/AuthController.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using ControleFinanceiro.Application.Services;
+using ControleFinanceiro.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace ControleFinanceiro.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AuthController : ControllerBase
+    {
+        private readonly IUsuarioAppService _service;
+        private readonly IConfiguration _config;
+
+        public AuthController(IUsuarioAppService service, IConfiguration config)
+        {
+            _service = service;
+            _config = config;
+        }
+
+        [HttpPost("register")]
+        public IActionResult Register([FromBody] Usuario usuario)
+        {
+            _service.Registrar(usuario);
+            return Ok();
+        }
+
+        public class LoginDto
+        {
+            public string Email { get; set; }
+            public string Senha { get; set; }
+        }
+
+        [HttpPost("login")]
+        public IActionResult Login([FromBody] LoginDto dto)
+        {
+            var user = _service.Autenticar(dto.Email, dto.Senha);
+            if (user == null)
+                return Unauthorized();
+
+            var token = GenerateToken(user);
+            return Ok(new { token });
+        }
+
+        private string GenerateToken(Usuario usuario)
+        {
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]));
+            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+            var claims = new[]
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, usuario.Email),
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+            };
+
+            var token = new JwtSecurityToken(
+                issuer: _config["Jwt:Issuer"],
+                audience: _config["Jwt:Audience"],
+                claims: claims,
+                expires: DateTime.UtcNow.AddHours(1),
+                signingCredentials: creds);
+
+            return new JwtSecurityTokenHandler().WriteToken(token);
+        }
+    }
+}

--- a/ControleFinanceiro.Api/Controllers/CartoesController.cs
+++ b/ControleFinanceiro.Api/Controllers/CartoesController.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using ControleFinanceiro.Application.Services;
 using ControleFinanceiro.Domain.Entities;
 
 namespace ControleFinanceiro.Api.Controllers
 {
+    [Authorize]
     [ApiController]
     [Route("api/[controller]")]
     public class CartoesController : ControllerBase

--- a/ControleFinanceiro.Api/Controllers/ContasPagarController.cs
+++ b/ControleFinanceiro.Api/Controllers/ContasPagarController.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using ControleFinanceiro.Application.Services;
 using ControleFinanceiro.Domain.Entities;
 
 namespace ControleFinanceiro.Api.Controllers
 {
+    [Authorize]
     [ApiController]
     [Route("api/[controller]")]
     public class ContasPagarController : ControllerBase

--- a/ControleFinanceiro.Api/Controllers/ContasReceberController.cs
+++ b/ControleFinanceiro.Api/Controllers/ContasReceberController.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using ControleFinanceiro.Application.Services;
 using ControleFinanceiro.Domain.Entities;
 
 namespace ControleFinanceiro.Api.Controllers
 {
+    [Authorize]
     [ApiController]
     [Route("api/[controller]")]
     public class ContasReceberController : ControllerBase

--- a/ControleFinanceiro.Api/Controllers/MovimentacoesController.cs
+++ b/ControleFinanceiro.Api/Controllers/MovimentacoesController.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using ControleFinanceiro.Application.Services;
 using ControleFinanceiro.Domain.Entities;
 
 namespace ControleFinanceiro.Api.Controllers
 {
+    [Authorize]
     [ApiController]
     [Route("api/[controller]")]
     public class MovimentacoesController : ControllerBase

--- a/ControleFinanceiro.Api/Controllers/PessoasController.cs
+++ b/ControleFinanceiro.Api/Controllers/PessoasController.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using ControleFinanceiro.Application.Services;
 using ControleFinanceiro.Domain.Entities;
 
 namespace ControleFinanceiro.Api.Controllers
 {
+    [Authorize]
     [ApiController]
     [Route("api/[controller]")]
     public class PessoasController : ControllerBase

--- a/ControleFinanceiro.Api/Controllers/TransactionsController.cs
+++ b/ControleFinanceiro.Api/Controllers/TransactionsController.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using ControleFinanceiro.Application.Services;
 using ControleFinanceiro.Domain.Entities;
 
 namespace ControleFinanceiro.Api.Controllers
 {
+    [Authorize]
     [ApiController]
     [Route("api/[controller]")]
     public class TransactionsController : ControllerBase

--- a/ControleFinanceiro.Api/Program.cs
+++ b/ControleFinanceiro.Api/Program.cs
@@ -3,6 +3,9 @@ using ControleFinanceiro.Application.Services;
 using ControleFinanceiro.Domain.Repositories;
 using ControleFinanceiro.Infrastructure.Repositories;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 
 namespace ControleFinanceiro.Api
 {
@@ -22,6 +25,7 @@ namespace ControleFinanceiro.Api
             builder.Services.AddScoped<IContaReceberRepository, ContaReceberRepository>();
             builder.Services.AddScoped<IMovimentacaoFinanceiraRepository, MovimentacaoFinanceiraRepository>();
             builder.Services.AddScoped<ITransactionRepository, TransactionRepository>();
+            builder.Services.AddScoped<IUsuarioRepository, UsuarioRepository>();
 
             builder.Services.AddScoped<IPessoaAppService, PessoaAppService>();
             builder.Services.AddScoped<ICartaoAppService, CartaoAppService>();
@@ -29,6 +33,25 @@ namespace ControleFinanceiro.Api
             builder.Services.AddScoped<IContaReceberAppService, ContaReceberAppService>();
             builder.Services.AddScoped<IMovimentacaoFinanceiraAppService, MovimentacaoFinanceiraAppService>();
             builder.Services.AddScoped<ITransactionAppService, TransactionAppService>();
+            builder.Services.AddScoped<IUsuarioAppService, UsuarioAppService>();
+
+            var jwtSection = builder.Configuration.GetSection("Jwt");
+            builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer(options =>
+                {
+                    options.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidateIssuer = true,
+                        ValidateAudience = true,
+                        ValidateLifetime = true,
+                        ValidateIssuerSigningKey = true,
+                        ValidIssuer = jwtSection["Issuer"],
+                        ValidAudience = jwtSection["Audience"],
+                        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSection["Key"]))
+                    };
+                });
+
+            builder.Services.AddAuthorization();
 
             builder.Services.AddControllers();
             builder.Services.AddEndpointsApiExplorer();
@@ -41,6 +64,9 @@ namespace ControleFinanceiro.Api
                 app.UseSwagger();
                 app.UseSwaggerUI();
             }
+
+            app.UseAuthentication();
+            app.UseAuthorization();
 
             app.MapControllers();
 

--- a/ControleFinanceiro.Api/appsettings.json
+++ b/ControleFinanceiro.Api/appsettings.json
@@ -1,5 +1,10 @@
 {
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=ControleFinanceiroDb;Trusted_Connection=True;"
+  },
+  "Jwt": {
+    "Key": "SuperSecretKey",
+    "Issuer": "ControleFinanceiroApi",
+    "Audience": "ControleFinanceiroApiUsers"
   }
 }

--- a/ControleFinanceiro.Application/Services/IUsuarioAppService.cs
+++ b/ControleFinanceiro.Application/Services/IUsuarioAppService.cs
@@ -1,0 +1,10 @@
+using ControleFinanceiro.Domain.Entities;
+
+namespace ControleFinanceiro.Application.Services
+{
+    public interface IUsuarioAppService
+    {
+        void Registrar(Usuario usuario);
+        Usuario Autenticar(string email, string senha);
+    }
+}

--- a/ControleFinanceiro.Application/Services/UsuarioAppService.cs
+++ b/ControleFinanceiro.Application/Services/UsuarioAppService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using ControleFinanceiro.Domain.Entities;
+using ControleFinanceiro.Domain.Repositories;
+
+namespace ControleFinanceiro.Application.Services
+{
+    public class UsuarioAppService : IUsuarioAppService
+    {
+        private readonly IUsuarioRepository _repository;
+
+        public UsuarioAppService(IUsuarioRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public void Registrar(Usuario usuario)
+        {
+            if (_repository.GetByEmail(usuario.Email) != null)
+                throw new InvalidOperationException("Usuário já cadastrado.");
+
+            usuario.SenhaHash = HashSenha(usuario.SenhaHash);
+            _repository.Add(usuario);
+        }
+
+        public Usuario Autenticar(string email, string senha)
+        {
+            var user = _repository.GetByEmail(email);
+            if (user == null)
+                return null;
+
+            var hash = HashSenha(senha);
+            return user.SenhaHash == hash ? user : null;
+        }
+
+        private static string HashSenha(string senha)
+        {
+            using var sha = SHA256.Create();
+            var bytes = Encoding.UTF8.GetBytes(senha);
+            var hash = sha.ComputeHash(bytes);
+            return Convert.ToBase64String(hash);
+        }
+    }
+}

--- a/ControleFinanceiro.Domain/Entities/Usuario.cs
+++ b/ControleFinanceiro.Domain/Entities/Usuario.cs
@@ -1,0 +1,15 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ControleFinanceiro.Domain.Entities
+{
+    public class Usuario : BaseEntity
+    {
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; }
+
+        [Required]
+        public string SenhaHash { get; set; }
+    }
+}

--- a/ControleFinanceiro.Domain/Repositories/IUsuarioRepository.cs
+++ b/ControleFinanceiro.Domain/Repositories/IUsuarioRepository.cs
@@ -1,0 +1,12 @@
+using System;
+using ControleFinanceiro.Domain.Entities;
+
+namespace ControleFinanceiro.Domain.Repositories
+{
+    public interface IUsuarioRepository
+    {
+        void Add(Usuario usuario);
+        Usuario GetByEmail(string email);
+        Usuario GetById(Guid id);
+    }
+}

--- a/ControleFinanceiro.Infrastructure/Data/FinanceiroDbContext.cs
+++ b/ControleFinanceiro.Infrastructure/Data/FinanceiroDbContext.cs
@@ -16,6 +16,7 @@ namespace ControleFinanceiro.Infrastructure.Data
         public DbSet<ContaReceber> ContasReceber { get; set; }
         public DbSet<MovimentacaoFinanceira> MovimentacoesFinanceiras { get; set; }
         public DbSet<Transaction> Transactions { get; set; }
+        public DbSet<Usuario> Usuarios { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -40,6 +41,10 @@ namespace ControleFinanceiro.Infrastructure.Data
                 .HasOne(m => m.Pessoa)
                 .WithMany(p => p.MovimentacoesFinanceiras)
                 .HasForeignKey(m => m.PessoaId);
+
+            modelBuilder.Entity<Usuario>()
+                .HasIndex(u => u.Email)
+                .IsUnique();
         }
     }
 }

--- a/ControleFinanceiro.Infrastructure/Repositories/UsuarioRepository.cs
+++ b/ControleFinanceiro.Infrastructure/Repositories/UsuarioRepository.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq;
+using ControleFinanceiro.Domain.Entities;
+using ControleFinanceiro.Domain.Repositories;
+using ControleFinanceiro.Infrastructure.Data;
+
+namespace ControleFinanceiro.Infrastructure.Repositories
+{
+    public class UsuarioRepository : IUsuarioRepository
+    {
+        private readonly FinanceiroDbContext _context;
+
+        public UsuarioRepository(FinanceiroDbContext context)
+        {
+            _context = context;
+        }
+
+        public void Add(Usuario usuario)
+        {
+            _context.Usuarios.Add(usuario);
+            _context.SaveChanges();
+        }
+
+        public Usuario GetByEmail(string email)
+        {
+            return _context.Usuarios.FirstOrDefault(u => u.Email == email);
+        }
+
+        public Usuario GetById(Guid id)
+        {
+            return _context.Usuarios.Find(id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement basic JWT-based authentication with new Usuario entity
- secure API controllers via `[Authorize]`
- add AuthController for user registration and login
- wire up authentication/authorization services
- store JWT settings in `appsettings.json`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b903a3b80832c98a778539557d29f