### PR TITLE
Add standard .NET gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Build results
+bin/
+obj/
+
+# Visual Studio
+.vs/
+*.user
+*.suo
+*.sln.docstates
+
+# Others
+*.db
+*.log
+
+# ASP.NET Core secrets
+**/appsettings.Development.json
+
+# Resharper
+*.DotSettings.user
+
+# Mac
+.DS_Store
+# Windows
+Thumbs.db


### PR DESCRIPTION
## Summary
- add a .gitignore file with common patterns for .NET

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688b99133da8832cab5eb1e42ab5324f