### PR TITLE
Add telefone and ativo fields to Pessoa

### DIFF
--- a/ControleFinanceiro.Application/Services/PessoaAppService.cs
+++ b/ControleFinanceiro.Application/Services/PessoaAppService.cs
@@ -21,6 +21,7 @@ namespace ControleFinanceiro.Application.Services
                 throw new InvalidOperationException("Documento já cadastrado.");
             }
 
+            pessoa.Ativo = true;
             _pessoaRepository.Add(pessoa);
         }
 

--- a/ControleFinanceiro.Domain/Entities/Pessoa.cs
+++ b/ControleFinanceiro.Domain/Entities/Pessoa.cs
@@ -18,6 +18,12 @@ namespace ControleFinanceiro.Domain.Entities
         [StringLength(14)]
         public string Documento { get; set; }
 
+        [Phone]
+        [StringLength(20)]
+        public string? Telefone { get; set; }
+
+        public bool Ativo { get; set; } = true;
+
         public DateTime? DataNascimento { get; set; }
 
         public ICollection<Cartao> Cartoes { get; set; } = new List<Cartao>();

--- a/ControleFinanceiro.Infrastructure/Data/FinanceiroDbContext.cs
+++ b/ControleFinanceiro.Infrastructure/Data/FinanceiroDbContext.cs
@@ -22,6 +22,14 @@ namespace ControleFinanceiro.Infrastructure.Data
         {
             base.OnModelCreating(modelBuilder);
 
+            modelBuilder.Entity<Pessoa>()
+                .Property(p => p.Telefone)
+                .HasMaxLength(20);
+
+            modelBuilder.Entity<Pessoa>()
+                .Property(p => p.Ativo)
+                .HasDefaultValue(true);
+
             modelBuilder.Entity<Cartao>()
                 .HasOne(c => c.Pessoa)
                 .WithMany(p => p.Cartoes)

--- a/ControleFinanceiro.Infrastructure/Data/Migrations/20250731160000_AddTelefoneAndAtivoToPessoa.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/20250731160000_AddTelefoneAndAtivoToPessoa.cs
@@ -1,0 +1,41 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ControleFinanceiro.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTelefoneAndAtivoToPessoa : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Telefone",
+                table: "Pessoas",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Ativo",
+                table: "Pessoas",
+                type: "bit",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Telefone",
+                table: "Pessoas");
+
+            migrationBuilder.DropColumn(
+                name: "Ativo",
+                table: "Pessoas");
+        }
+    }
+}

--- a/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
@@ -160,6 +160,14 @@ namespace ControleFinanceiro.Infrastructure.Data.Migrations
                     .HasMaxLength(14)
                     .HasColumnType("nvarchar(14)");
 
+                b.Property<bool>("Ativo")
+                    .HasColumnType("bit")
+                    .HasDefaultValue(true);
+
+                b.Property<string>("Telefone")
+                    .HasMaxLength(20)
+                    .HasColumnType("nvarchar(20)");
+
                 b.Property<string>("Email")
                     .IsRequired()
                     .HasColumnType("nvarchar(max)");

--- a/ControleFinanceiro.Infrastructure/Repositories/PessoaRepository.cs
+++ b/ControleFinanceiro.Infrastructure/Repositories/PessoaRepository.cs
@@ -27,29 +27,30 @@ namespace ControleFinanceiro.Infrastructure.Repositories
             var entity = _context.Pessoas.Find(id);
             if (entity != null)
             {
-                _context.Pessoas.Remove(entity);
+                entity.Ativo = false;
                 _context.SaveChanges();
             }
         }
 
         public IEnumerable<Pessoa> GetAll()
         {
-            return _context.Pessoas.ToList();
+            return _context.Pessoas.Where(p => p.Ativo).ToList();
         }
 
         public Pessoa GetByDocumento(string documento)
         {
-            return _context.Pessoas.FirstOrDefault(p => p.Documento == documento);
+            return _context.Pessoas.FirstOrDefault(p => p.Documento == documento && p.Ativo);
         }
 
         public Pessoa GetById(Guid id)
         {
-            return _context.Pessoas.Find(id);
+            var pessoa = _context.Pessoas.Find(id);
+            return pessoa != null && pessoa.Ativo ? pessoa : null;
         }
 
         public IEnumerable<Pessoa> GetByNome(string nome)
         {
-            return _context.Pessoas.Where(p => p.Nome.Contains(nome)).ToList();
+            return _context.Pessoas.Where(p => p.Nome.Contains(nome) && p.Ativo).ToList();
         }
 
         public void Update(Pessoa pessoa)


### PR DESCRIPTION
## Summary
- add `Telefone` and `Ativo` to `Pessoa`
- map new fields in `FinanceiroDbContext`
- adjust `PessoaRepository` and `PessoaAppService`
- create EF migration for new columns

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ba8b33ba4832c9a60e2b8d376500f