### PR TITLE
Add Bandeira and NumeroFinal

### DIFF
--- a/ControleFinanceiro.Api/Controllers/CartoesController.cs
+++ b/ControleFinanceiro.Api/Controllers/CartoesController.cs
@@ -43,6 +43,7 @@ namespace ControleFinanceiro.Api.Controllers
         [HttpPost]
         public IActionResult Create(Cartao cartao)
         {
+            cartao.NumeroFinal = cartao.Numero?.Length > 4 ? cartao.Numero[^4..] : cartao.Numero;
             _service.Add(cartao);
             return CreatedAtAction(nameof(GetById), new { id = cartao.Id }, cartao);
         }
@@ -52,6 +53,7 @@ namespace ControleFinanceiro.Api.Controllers
         {
             if (id != cartao.Id)
                 return BadRequest();
+            cartao.NumeroFinal = cartao.Numero?.Length > 4 ? cartao.Numero[^4..] : cartao.Numero;
             _service.Update(cartao);
             return NoContent();
         }

--- a/ControleFinanceiro.Application/Services/CartaoAppService.cs
+++ b/ControleFinanceiro.Application/Services/CartaoAppService.cs
@@ -16,6 +16,11 @@ namespace ControleFinanceiro.Application.Services
 
         public void Add(Cartao cartao)
         {
+            if (string.IsNullOrWhiteSpace(cartao.Bandeira))
+            {
+                throw new InvalidOperationException("Bandeira é obrigatória.");
+            }
+
             if (cartao.Limite <= 0)
             {
                 throw new InvalidOperationException("Limite deve ser maior que zero.");
@@ -24,11 +29,19 @@ namespace ControleFinanceiro.Application.Services
             {
                 throw new InvalidOperationException("Data de validade inválida.");
             }
+
+            cartao.NumeroFinal = ObterNumeroFinal(cartao.Numero);
+
             _repository.Add(cartao);
         }
 
         public void Update(Cartao cartao)
         {
+            if (string.IsNullOrWhiteSpace(cartao.Bandeira))
+            {
+                throw new InvalidOperationException("Bandeira é obrigatória.");
+            }
+
             if (cartao.Limite <= 0)
             {
                 throw new InvalidOperationException("Limite deve ser maior que zero.");
@@ -37,7 +50,20 @@ namespace ControleFinanceiro.Application.Services
             {
                 throw new InvalidOperationException("Data de validade inválida.");
             }
+
+            cartao.NumeroFinal = ObterNumeroFinal(cartao.Numero);
+
             _repository.Update(cartao);
+        }
+
+        private static string ObterNumeroFinal(string numero)
+        {
+            if (string.IsNullOrEmpty(numero))
+            {
+                return string.Empty;
+            }
+
+            return numero.Length > 4 ? numero[^4..] : numero;
         }
 
         public void Delete(Guid id)

--- a/ControleFinanceiro.Domain/Entities/Cartao.cs
+++ b/ControleFinanceiro.Domain/Entities/Cartao.cs
@@ -13,6 +13,13 @@ namespace ControleFinanceiro.Domain.Entities
         public string Numero { get; set; }
 
         [Required]
+        [StringLength(20)]
+        public string Bandeira { get; set; }
+
+        [StringLength(4)]
+        public string NumeroFinal { get; set; }
+
+        [Required]
         [StringLength(100)]
         public string NomeImpresso { get; set; }
 

--- a/ControleFinanceiro.Infrastructure/Data/Migrations/20250731160000_AddCartaoBandeiraNumeroFinal.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/20250731160000_AddCartaoBandeiraNumeroFinal.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ControleFinanceiro.Infrastructure.Data.Migrations
+{
+    public partial class AddCartaoBandeiraNumeroFinal : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Bandeira",
+                table: "Cartoes",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "NumeroFinal",
+                table: "Cartoes",
+                type: "nvarchar(4)",
+                maxLength: 4,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Bandeira",
+                table: "Cartoes");
+
+            migrationBuilder.DropColumn(
+                name: "NumeroFinal",
+                table: "Cartoes");
+        }
+    }
+}
+

--- a/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
@@ -38,6 +38,15 @@ namespace ControleFinanceiro.Infrastructure.Data.Migrations
                     .HasMaxLength(16)
                     .HasColumnType("nvarchar(16)");
 
+                b.Property<string>("Bandeira")
+                    .IsRequired()
+                    .HasMaxLength(20)
+                    .HasColumnType("nvarchar(20)");
+
+                b.Property<string>("NumeroFinal")
+                    .HasMaxLength(4)
+                    .HasColumnType("nvarchar(4)");
+
                 b.Property<Guid>("PessoaId")
                     .HasColumnType("uniqueidentifier");
 


### PR DESCRIPTION
## Summary
- add `Bandeira` and `NumeroFinal` fields to `Cartao`
- compute and validate new fields in `CartaoAppService`
- compute `NumeroFinal` in controller
- add EF migration for the new columns and update model snapshot

## Testing
- `dotnet build ControleFinanceiro.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ba8b42c2c832c8f55f8383814611f