### PR TITLE
Add FormaPagamento support

### DIFF
--- a/ControleFinanceiro.Api/Controllers/FormasPagamentoController.cs
+++ b/ControleFinanceiro.Api/Controllers/FormasPagamentoController.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using ControleFinanceiro.Application.Services;
+using ControleFinanceiro.Domain.Entities;
+
+namespace ControleFinanceiro.Api.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("api/[controller]")]
+    public class FormasPagamentoController : ControllerBase
+    {
+        private readonly IFormaPagamentoAppService _service;
+
+        public FormasPagamentoController(IFormaPagamentoAppService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet("{id}")]
+        public ActionResult<FormaPagamento> GetById(Guid id)
+        {
+            var forma = _service.GetById(id);
+            if (forma == null)
+                return NotFound();
+            return Ok(forma);
+        }
+
+        [HttpGet("pessoa/{pessoaId}")]
+        public ActionResult<IEnumerable<FormaPagamento>> GetByPessoa(Guid pessoaId)
+        {
+            return Ok(_service.GetByPessoa(pessoaId));
+        }
+
+        [HttpGet("cartao/{cartaoId}")]
+        public ActionResult<IEnumerable<FormaPagamento>> GetByCartao(Guid cartaoId)
+        {
+            return Ok(_service.GetByCartao(cartaoId));
+        }
+
+        [HttpPost]
+        public IActionResult Create(FormaPagamento forma)
+        {
+            _service.Add(forma);
+            return CreatedAtAction(nameof(GetById), new { id = forma.Id }, forma);
+        }
+
+        [HttpPut("{id}")]
+        public IActionResult Update(Guid id, FormaPagamento forma)
+        {
+            if (id != forma.Id)
+                return BadRequest();
+            _service.Update(forma);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public IActionResult Delete(Guid id)
+        {
+            _service.Delete(id);
+            return NoContent();
+        }
+    }
+}

--- a/ControleFinanceiro.Api/Program.cs
+++ b/ControleFinanceiro.Api/Program.cs
@@ -26,6 +26,7 @@ namespace ControleFinanceiro.Api
             builder.Services.AddScoped<IMovimentacaoFinanceiraRepository, MovimentacaoFinanceiraRepository>();
             builder.Services.AddScoped<ITransactionRepository, TransactionRepository>();
             builder.Services.AddScoped<IUsuarioRepository, UsuarioRepository>();
+            builder.Services.AddScoped<IFormaPagamentoRepository, FormaPagamentoRepository>();
 
             builder.Services.AddScoped<IPessoaAppService, PessoaAppService>();
             builder.Services.AddScoped<ICartaoAppService, CartaoAppService>();
@@ -34,6 +35,7 @@ namespace ControleFinanceiro.Api
             builder.Services.AddScoped<IMovimentacaoFinanceiraAppService, MovimentacaoFinanceiraAppService>();
             builder.Services.AddScoped<ITransactionAppService, TransactionAppService>();
             builder.Services.AddScoped<IUsuarioAppService, UsuarioAppService>();
+            builder.Services.AddScoped<IFormaPagamentoAppService, FormaPagamentoAppService>();
 
             var jwtSection = builder.Configuration.GetSection("Jwt");
             builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/ControleFinanceiro.Application/Services/FormaPagamentoAppService.cs
+++ b/ControleFinanceiro.Application/Services/FormaPagamentoAppService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using ControleFinanceiro.Domain.Entities;
+using ControleFinanceiro.Domain.Repositories;
+
+namespace ControleFinanceiro.Application.Services
+{
+    public class FormaPagamentoAppService : IFormaPagamentoAppService
+    {
+        private readonly IFormaPagamentoRepository _repository;
+
+        public FormaPagamentoAppService(IFormaPagamentoRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public void Add(FormaPagamento forma)
+        {
+            if (string.IsNullOrWhiteSpace(forma.Descricao))
+            {
+                throw new InvalidOperationException("Descricao obrigatoria.");
+            }
+            _repository.Add(forma);
+        }
+
+        public void Update(FormaPagamento forma)
+        {
+            if (string.IsNullOrWhiteSpace(forma.Descricao))
+            {
+                throw new InvalidOperationException("Descricao obrigatoria.");
+            }
+            _repository.Update(forma);
+        }
+
+        public void Delete(Guid id)
+        {
+            _repository.Delete(id);
+        }
+
+        public FormaPagamento GetById(Guid id)
+        {
+            return _repository.GetById(id);
+        }
+
+        public IEnumerable<FormaPagamento> GetByPessoa(Guid pessoaId)
+        {
+            return _repository.GetByPessoa(pessoaId);
+        }
+
+        public IEnumerable<FormaPagamento> GetByCartao(Guid cartaoId)
+        {
+            return _repository.GetByCartao(cartaoId);
+        }
+    }
+}

--- a/ControleFinanceiro.Application/Services/IFormaPagamentoAppService.cs
+++ b/ControleFinanceiro.Application/Services/IFormaPagamentoAppService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using ControleFinanceiro.Domain.Entities;
+
+namespace ControleFinanceiro.Application.Services
+{
+    public interface IFormaPagamentoAppService
+    {
+        void Add(FormaPagamento forma);
+        void Update(FormaPagamento forma);
+        void Delete(Guid id);
+        FormaPagamento GetById(Guid id);
+        IEnumerable<FormaPagamento> GetByPessoa(Guid pessoaId);
+        IEnumerable<FormaPagamento> GetByCartao(Guid cartaoId);
+    }
+}

--- a/ControleFinanceiro.Domain/Entities/FormaPagamento.cs
+++ b/ControleFinanceiro.Domain/Entities/FormaPagamento.cs
@@ -1,0 +1,22 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ControleFinanceiro.Domain.Entities
+{
+    public class FormaPagamento : BaseEntity
+    {
+        [Required]
+        public Guid PessoaId { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public string Descricao { get; set; }
+
+        public bool BaixarAutomaticamente { get; set; }
+
+        public Guid? CartaoId { get; set; }
+
+        public Pessoa Pessoa { get; set; }
+        public Cartao Cartao { get; set; }
+    }
+}

--- a/ControleFinanceiro.Domain/Entities/Pessoa.cs
+++ b/ControleFinanceiro.Domain/Entities/Pessoa.cs
@@ -24,5 +24,6 @@ namespace ControleFinanceiro.Domain.Entities
         public ICollection<ContaPagar> ContasPagar { get; set; } = new List<ContaPagar>();
         public ICollection<ContaReceber> ContasReceber { get; set; } = new List<ContaReceber>();
         public ICollection<MovimentacaoFinanceira> MovimentacoesFinanceiras { get; set; } = new List<MovimentacaoFinanceira>();
+        public ICollection<FormaPagamento> FormasPagamento { get; set; } = new List<FormaPagamento>();
     }
 }

--- a/ControleFinanceiro.Domain/Repositories/IFormaPagamentoRepository.cs
+++ b/ControleFinanceiro.Domain/Repositories/IFormaPagamentoRepository.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using ControleFinanceiro.Domain.Entities;
+
+namespace ControleFinanceiro.Domain.Repositories
+{
+    public interface IFormaPagamentoRepository
+    {
+        FormaPagamento GetById(Guid id);
+        IEnumerable<FormaPagamento> GetByPessoa(Guid pessoaId);
+        IEnumerable<FormaPagamento> GetByCartao(Guid cartaoId);
+        void Add(FormaPagamento forma);
+        void Update(FormaPagamento forma);
+        void Delete(Guid id);
+    }
+}

--- a/ControleFinanceiro.Infrastructure/Data/FinanceiroDbContext.cs
+++ b/ControleFinanceiro.Infrastructure/Data/FinanceiroDbContext.cs
@@ -15,6 +15,7 @@ namespace ControleFinanceiro.Infrastructure.Data
         public DbSet<ContaPagar> ContasPagar { get; set; }
         public DbSet<ContaReceber> ContasReceber { get; set; }
         public DbSet<MovimentacaoFinanceira> MovimentacoesFinanceiras { get; set; }
+        public DbSet<FormaPagamento> FormasPagamento { get; set; }
         public DbSet<Transaction> Transactions { get; set; }
         public DbSet<Usuario> Usuarios { get; set; }
 
@@ -41,6 +42,16 @@ namespace ControleFinanceiro.Infrastructure.Data
                 .HasOne(m => m.Pessoa)
                 .WithMany(p => p.MovimentacoesFinanceiras)
                 .HasForeignKey(m => m.PessoaId);
+
+            modelBuilder.Entity<FormaPagamento>()
+                .HasOne(f => f.Pessoa)
+                .WithMany(p => p.FormasPagamento)
+                .HasForeignKey(f => f.PessoaId);
+
+            modelBuilder.Entity<FormaPagamento>()
+                .HasOne(f => f.Cartao)
+                .WithMany()
+                .HasForeignKey(f => f.CartaoId);
 
             modelBuilder.Entity<Usuario>()
                 .HasIndex(u => u.Email)

--- a/ControleFinanceiro.Infrastructure/Data/Migrations/20250731151519_AddFormaPagamento.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/20250731151519_AddFormaPagamento.cs
@@ -1,0 +1,58 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ControleFinanceiro.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFormaPagamento : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FormasPagamento",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PessoaId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Descricao = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    BaixarAutomaticamente = table.Column<bool>(type: "bit", nullable: false),
+                    CartaoId = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FormasPagamento", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FormasPagamento_Cartoes_CartaoId",
+                        column: x => x.CartaoId,
+                        principalTable: "Cartoes",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_FormasPagamento_Pessoas_PessoaId",
+                        column: x => x.PessoaId,
+                        principalTable: "Pessoas",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FormasPagamento_CartaoId",
+                table: "FormasPagamento",
+                column: "CartaoId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FormasPagamento_PessoaId",
+                table: "FormasPagamento",
+                column: "PessoaId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FormasPagamento");
+        }
+    }
+}

--- a/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
@@ -146,6 +146,35 @@ namespace ControleFinanceiro.Infrastructure.Data.Migrations
                 b.ToTable("MovimentacoesFinanceiras");
             });
 
+            modelBuilder.Entity("ControleFinanceiro.Domain.Entities.FormaPagamento", b =>
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<bool>("BaixarAutomaticamente")
+                    .HasColumnType("bit");
+
+                b.Property<Guid?>("CartaoId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Descricao")
+                    .IsRequired()
+                    .HasMaxLength(100)
+                    .HasColumnType("nvarchar(100)");
+
+                b.Property<Guid>("PessoaId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.HasKey("Id");
+
+                b.HasIndex("CartaoId");
+
+                b.HasIndex("PessoaId");
+
+                b.ToTable("FormasPagamento");
+            });
+
             modelBuilder.Entity("ControleFinanceiro.Domain.Entities.Pessoa", b =>
             {
                 b.Property<Guid>("Id")

--- a/ControleFinanceiro.Infrastructure/Repositories/FormaPagamentoRepository.cs
+++ b/ControleFinanceiro.Infrastructure/Repositories/FormaPagamentoRepository.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ControleFinanceiro.Domain.Entities;
+using ControleFinanceiro.Domain.Repositories;
+using ControleFinanceiro.Infrastructure.Data;
+
+namespace ControleFinanceiro.Infrastructure.Repositories
+{
+    public class FormaPagamentoRepository : IFormaPagamentoRepository
+    {
+        private readonly FinanceiroDbContext _context;
+
+        public FormaPagamentoRepository(FinanceiroDbContext context)
+        {
+            _context = context;
+        }
+
+        public void Add(FormaPagamento forma)
+        {
+            _context.FormasPagamento.Add(forma);
+            _context.SaveChanges();
+        }
+
+        public void Delete(Guid id)
+        {
+            var entity = _context.FormasPagamento.Find(id);
+            if (entity != null)
+            {
+                _context.FormasPagamento.Remove(entity);
+                _context.SaveChanges();
+            }
+        }
+
+        public FormaPagamento GetById(Guid id)
+        {
+            return _context.FormasPagamento.Find(id);
+        }
+
+        public IEnumerable<FormaPagamento> GetByPessoa(Guid pessoaId)
+        {
+            return _context.FormasPagamento.Where(f => f.PessoaId == pessoaId).ToList();
+        }
+
+        public IEnumerable<FormaPagamento> GetByCartao(Guid cartaoId)
+        {
+            return _context.FormasPagamento.Where(f => f.CartaoId == cartaoId).ToList();
+        }
+
+        public void Update(FormaPagamento forma)
+        {
+            _context.FormasPagamento.Update(forma);
+            _context.SaveChanges();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add FormaPagamento entity with automatic settlement field and optional card
- create repository/service/controller for FormaPagamento
- register new components
- update DbContext and migrations

## Testing
- `dotnet build ControleFinanceiro.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ba8b5a6cc832c8b5bf741393dff9f