### PR TITLE
Add Usuarios and Transactions migration

### DIFF
--- a/ControleFinanceiro.Infrastructure/Data/Migrations/20250801010000_AddUsuariosAndTransactions.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/20250801010000_AddUsuariosAndTransactions.cs
@@ -1,0 +1,71 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ControleFinanceiro.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUsuariosAndTransactions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Usuarios",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    SenhaHash = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Usuarios", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Transactions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PessoaId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Tipo = table.Column<int>(type: "int", nullable: false),
+                    Valor = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    Data = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Descricao = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Transactions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Transactions_Pessoas_PessoaId",
+                        column: x => x.PessoaId,
+                        principalTable: "Pessoas",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Usuarios_Email",
+                table: "Usuarios",
+                column: "Email",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Transactions_PessoaId",
+                table: "Transactions",
+                column: "PessoaId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Transactions");
+
+            migrationBuilder.DropTable(
+                name: "Usuarios");
+        }
+    }
+}

--- a/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
@@ -250,6 +250,57 @@ namespace ControleFinanceiro.Infrastructure.Data.Migrations
 
                 b.ToTable("Pessoas");
             });
+
+            modelBuilder.Entity("ControleFinanceiro.Domain.Entities.Usuario", b =>
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<string>("Email")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("SenhaHash")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("Email")
+                    .IsUnique();
+
+                b.ToTable("Usuarios");
+            });
+
+            modelBuilder.Entity("ControleFinanceiro.Domain.Entities.Transaction", b =>
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<DateTime>("Data")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Descricao")
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                b.Property<Guid>("PessoaId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<int>("Tipo")
+                    .HasColumnType("int");
+
+                b.Property<decimal>("Valor")
+                    .HasColumnType("decimal(18,2)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("PessoaId");
+
+                b.ToTable("Transactions");
+            });
 #pragma warning restore 612, 618
         }
     }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Todos os projetos da solução estão configurados para o *Target Framework* `ne
    ```bash
    dotnet ef database update -s ControleFinanceiro.Api/ControleFinanceiro.Api.csproj -p ControleFinanceiro.Infrastructure/ControleFinanceiro.Infrastructure.csproj
    ```
+4. Quando novas entidades forem adicionadas, gere uma nova migração, por exemplo:
+   ```bash
+   dotnet ef migrations add AddUsuariosAndTransactions -s ControleFinanceiro.Api/ControleFinanceiro.Api.csproj -p ControleFinanceiro.Infrastructure/ControleFinanceiro.Infrastructure.csproj
+   dotnet ef database update -s ControleFinanceiro.Api/ControleFinanceiro.Api.csproj -p ControleFinanceiro.Infrastructure/ControleFinanceiro.Infrastructure.csproj
+   ```
 
 ## Build e execução da API
 


### PR DESCRIPTION
## Summary
- add EF Core migration to create `Usuarios` and `Transactions` tables
- update model snapshot to include the new entities
- document migration commands in README

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c3dfb1fe8832caa8faee09ba7e669