### PR TITLE
Add tests for app services

### DIFF
--- a/ControleFinanceiro.Tests/ControleFinanceiro.Tests.csproj
+++ b/ControleFinanceiro.Tests/ControleFinanceiro.Tests.csproj
@@ -14,5 +14,6 @@
   <ItemGroup>
     <ProjectReference Include="..\ControleFinanceiro.Application\ControleFinanceiro.Application.csproj" />
     <ProjectReference Include="..\ControleFinanceiro.Domain\ControleFinanceiro.Domain.csproj" />
+    <ProjectReference Include="..\ControleFinanceiro.Shared\ControleFinanceiro.Shared.csproj" />
   </ItemGroup>
 </Project>

--- a/ControleFinanceiro.Tests/Services/ContaBancariaCartaoEncryptionTests.cs
+++ b/ControleFinanceiro.Tests/Services/ContaBancariaCartaoEncryptionTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using ControleFinanceiro.Application.Services;
+using ControleFinanceiro.Domain.Entities;
+using ControleFinanceiro.Domain.Repositories;
+using ControleFinanceiro.Shared.Utils;
+
+namespace ControleFinanceiro.Tests.Services
+{
+    public class ContaBancariaCartaoEncryptionTests
+    {
+        private class InMemoryContaBancariaRepository : IContaBancariaRepository
+        {
+            public readonly List<ContaBancaria> Stored = new();
+
+            public void Add(ContaBancaria conta)
+            {
+                var enc = Crypto.Encrypt(conta.Numero, Constants.EncryptionKey);
+                Stored.Add(new ContaBancaria
+                {
+                    Id = conta.Id,
+                    PessoaId = conta.PessoaId,
+                    Banco = conta.Banco,
+                    Agencia = conta.Agencia,
+                    Numero = enc
+                });
+                conta.Numero = Crypto.Decrypt(enc, Constants.EncryptionKey);
+            }
+
+            public void Update(ContaBancaria conta)
+            {
+                Delete(conta.Id);
+                Add(conta);
+            }
+
+            public void Delete(Guid id)
+            {
+                Stored.RemoveAll(c => c.Id == id);
+            }
+
+            public ContaBancaria GetById(Guid id)
+            {
+                var entity = Stored.FirstOrDefault(c => c.Id == id);
+                if (entity == null) return null;
+                return new ContaBancaria
+                {
+                    Id = entity.Id,
+                    PessoaId = entity.PessoaId,
+                    Banco = entity.Banco,
+                    Agencia = entity.Agencia,
+                    Numero = Crypto.Decrypt(entity.Numero, Constants.EncryptionKey)
+                };
+            }
+
+            public IEnumerable<ContaBancaria> GetByPessoa(Guid pessoaId)
+            {
+                return Stored
+                    .Where(c => c.PessoaId == pessoaId)
+                    .Select(e => new ContaBancaria
+                    {
+                        Id = e.Id,
+                        PessoaId = e.PessoaId,
+                        Banco = e.Banco,
+                        Agencia = e.Agencia,
+                        Numero = Crypto.Decrypt(e.Numero, Constants.EncryptionKey)
+                    });
+            }
+        }
+
+        private class InMemoryCartaoRepository : ICartaoRepository
+        {
+            public readonly List<Cartao> Stored = new();
+
+            public void Add(Cartao cartao)
+            {
+                var enc = Crypto.Encrypt(cartao.Numero, Constants.EncryptionKey);
+                Stored.Add(new Cartao
+                {
+                    Id = cartao.Id,
+                    PessoaId = cartao.PessoaId,
+                    Bandeira = cartao.Bandeira,
+                    NomeImpresso = cartao.NomeImpresso,
+                    DataValidade = cartao.DataValidade,
+                    CodigoSeguranca = cartao.CodigoSeguranca,
+                    Limite = cartao.Limite,
+                    Numero = enc,
+                    NumeroFinal = cartao.NumeroFinal
+                });
+                cartao.Numero = Crypto.Decrypt(enc, Constants.EncryptionKey);
+            }
+
+            public void Update(Cartao cartao)
+            {
+                Delete(cartao.Id);
+                Add(cartao);
+            }
+
+            public void Delete(Guid id)
+            {
+                Stored.RemoveAll(c => c.Id == id);
+            }
+
+            public Cartao GetById(Guid id)
+            {
+                var e = Stored.FirstOrDefault(c => c.Id == id);
+                if (e == null) return null;
+                return new Cartao
+                {
+                    Id = e.Id,
+                    PessoaId = e.PessoaId,
+                    Bandeira = e.Bandeira,
+                    NomeImpresso = e.NomeImpresso,
+                    DataValidade = e.DataValidade,
+                    CodigoSeguranca = e.CodigoSeguranca,
+                    Limite = e.Limite,
+                    Numero = Crypto.Decrypt(e.Numero, Constants.EncryptionKey),
+                    NumeroFinal = e.NumeroFinal
+                };
+            }
+
+            public IEnumerable<Cartao> GetByPessoa(Guid pessoaId)
+            {
+                return Stored.Where(c => c.PessoaId == pessoaId)
+                    .Select(e => new Cartao
+                    {
+                        Id = e.Id,
+                        PessoaId = e.PessoaId,
+                        Bandeira = e.Bandeira,
+                        NomeImpresso = e.NomeImpresso,
+                        DataValidade = e.DataValidade,
+                        CodigoSeguranca = e.CodigoSeguranca,
+                        Limite = e.Limite,
+                        Numero = Crypto.Decrypt(e.Numero, Constants.EncryptionKey),
+                        NumeroFinal = e.NumeroFinal
+                    });
+            }
+
+            public IEnumerable<Cartao> GetVencendoAte(DateTime data) => Enumerable.Empty<Cartao>();
+        }
+
+        [Fact]
+        public void ContaBancaria_Add_ShouldEncryptAndDecryptNumero()
+        {
+            var repo = new InMemoryContaBancariaRepository();
+            var service = new ContaBancariaAppService(repo);
+
+            var conta = new ContaBancaria
+            {
+                Id = Guid.NewGuid(),
+                PessoaId = Guid.NewGuid(),
+                Banco = "Banco",
+                Agencia = "0001",
+                Numero = "123456"
+            };
+
+            service.Add(conta);
+
+            Assert.Single(repo.Stored);
+            Assert.NotEqual("123456", repo.Stored[0].Numero); // stored encrypted
+            var retorno = service.GetById(conta.Id);
+            Assert.Equal("123456", retorno.Numero); // decrypted on read
+        }
+
+        [Fact]
+        public void Cartao_Add_ShouldEncryptNumeroAndSetNumeroFinal()
+        {
+            var repo = new InMemoryCartaoRepository();
+            var service = new CartaoAppService(repo);
+
+            var cartao = new Cartao
+            {
+                Id = Guid.NewGuid(),
+                PessoaId = Guid.NewGuid(),
+                Numero = "1111222233334444",
+                Bandeira = "Visa",
+                NomeImpresso = "Test",
+                DataValidade = DateTime.Today.AddYears(1),
+                CodigoSeguranca = 123,
+                Limite = 1000m
+            };
+
+            service.Add(cartao);
+
+            Assert.Single(repo.Stored);
+            Assert.NotEqual("1111222233334444", repo.Stored[0].Numero); // encrypted
+            Assert.Equal("4444", cartao.NumeroFinal);
+            var retorno = service.GetById(cartao.Id);
+            Assert.Equal("1111222233334444", retorno.Numero); // decrypted
+        }
+    }
+}
+

--- a/ControleFinanceiro.Tests/Services/FormaPagamentoAppServiceTests.cs
+++ b/ControleFinanceiro.Tests/Services/FormaPagamentoAppServiceTests.cs
@@ -1,0 +1,37 @@
+using System;
+using Moq;
+using Xunit;
+using ControleFinanceiro.Application.Services;
+using ControleFinanceiro.Domain.Entities;
+using ControleFinanceiro.Domain.Repositories;
+
+namespace ControleFinanceiro.Tests.Services
+{
+    public class FormaPagamentoAppServiceTests
+    {
+        [Fact]
+        public void Add_DescricaoVazia_DeveLancarExcecao()
+        {
+            var repo = new Mock<IFormaPagamentoRepository>();
+            var service = new FormaPagamentoAppService(repo.Object);
+
+            var forma = new FormaPagamento { PessoaId = Guid.NewGuid(), Descricao = "" };
+
+            Assert.Throws<InvalidOperationException>(() => service.Add(forma));
+            repo.Verify(r => r.Add(It.IsAny<FormaPagamento>()), Times.Never);
+        }
+
+        [Fact]
+        public void Update_DescricaoVazia_DeveLancarExcecao()
+        {
+            var repo = new Mock<IFormaPagamentoRepository>();
+            var service = new FormaPagamentoAppService(repo.Object);
+
+            var forma = new FormaPagamento { Id = Guid.NewGuid(), PessoaId = Guid.NewGuid(), Descricao = null };
+
+            Assert.Throws<InvalidOperationException>(() => service.Update(forma));
+            repo.Verify(r => r.Update(It.IsAny<FormaPagamento>()), Times.Never);
+        }
+    }
+}
+

--- a/ControleFinanceiro.Tests/Services/UsuarioAppServiceTests.cs
+++ b/ControleFinanceiro.Tests/Services/UsuarioAppServiceTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using Moq;
+using Xunit;
+using ControleFinanceiro.Application.Services;
+using ControleFinanceiro.Domain.Entities;
+using ControleFinanceiro.Domain.Repositories;
+
+namespace ControleFinanceiro.Tests.Services
+{
+    public class UsuarioAppServiceTests
+    {
+        private static string Hash(string senha)
+        {
+            using var sha = SHA256.Create();
+            var bytes = Encoding.UTF8.GetBytes(senha);
+            var hash = sha.ComputeHash(bytes);
+            return Convert.ToBase64String(hash);
+        }
+
+        [Fact]
+        public void Registrar_NovoUsuario_DeveHashSenhaEAdicionar()
+        {
+            var repo = new Mock<IUsuarioRepository>();
+            repo.Setup(r => r.GetByEmail("a@a.com")).Returns((Usuario)null);
+            var service = new UsuarioAppService(repo.Object);
+
+            var usuario = new Usuario { Email = "a@a.com", SenhaHash = "123" };
+
+            service.Registrar(usuario);
+
+            var esperado = Hash("123");
+            Assert.Equal(esperado, usuario.SenhaHash);
+            repo.Verify(r => r.Add(It.Is<Usuario>(u => u.SenhaHash == esperado)), Times.Once);
+        }
+
+        [Fact]
+        public void Registrar_EmailExistente_DeveLancarExcecao()
+        {
+            var repo = new Mock<IUsuarioRepository>();
+            repo.Setup(r => r.GetByEmail("a@a.com")).Returns(new Usuario());
+            var service = new UsuarioAppService(repo.Object);
+
+            var usuario = new Usuario { Email = "a@a.com", SenhaHash = "123" };
+
+            Assert.Throws<InvalidOperationException>(() => service.Registrar(usuario));
+            repo.Verify(r => r.Add(It.IsAny<Usuario>()), Times.Never);
+        }
+
+        [Fact]
+        public void Autenticar_CredenciaisValidas_DeveRetornarUsuario()
+        {
+            var hash = Hash("123");
+            var repo = new Mock<IUsuarioRepository>();
+            repo.Setup(r => r.GetByEmail("a@a.com")).Returns(new Usuario { Email = "a@a.com", SenhaHash = hash });
+            var service = new UsuarioAppService(repo.Object);
+
+            var user = service.Autenticar("a@a.com", "123");
+
+            Assert.NotNull(user);
+        }
+
+        [Fact]
+        public void Autenticar_SenhaInvalida_DeveRetornarNull()
+        {
+            var repo = new Mock<IUsuarioRepository>();
+            repo.Setup(r => r.GetByEmail("a@a.com")).Returns(new Usuario { Email = "a@a.com", SenhaHash = Hash("123") });
+            var service = new UsuarioAppService(repo.Object);
+
+            var user = service.Autenticar("a@a.com", "321");
+
+            Assert.Null(user);
+        }
+
+        [Fact]
+        public void Autenticar_EmailInexistente_DeveRetornarNull()
+        {
+            var repo = new Mock<IUsuarioRepository>();
+            repo.Setup(r => r.GetByEmail("a@a.com")).Returns((Usuario)null);
+            var service = new UsuarioAppService(repo.Object);
+
+            var user = service.Autenticar("a@a.com", "123");
+
+            Assert.Null(user);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- test encryption in `ContaBancariaAppService` and `CartaoAppService`
- cover validation rules in `FormaPagamentoAppService`
- add registration/authentication tests for `UsuarioAppService`
- reference Shared project for Crypto utilities

## Testing
- `dotnet test --no-build` *(fails: `command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_688cb8cb15c4832c97d5eb0077defc71