### PR TITLE
Move encryption key to configuration

### DIFF
--- a/ControleFinanceiro.Api/Program.cs
+++ b/ControleFinanceiro.Api/Program.cs
@@ -2,6 +2,7 @@ using ControleFinanceiro.Infrastructure.Data;
 using ControleFinanceiro.Application.Services;
 using ControleFinanceiro.Domain.Repositories;
 using ControleFinanceiro.Infrastructure.Repositories;
+using ControleFinanceiro.Shared.Utils;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
@@ -35,6 +36,9 @@ namespace ControleFinanceiro.Api
             builder.Services.AddScoped<IMovimentacaoFinanceiraAppService, MovimentacaoFinanceiraAppService>();
             builder.Services.AddScoped<IUsuarioAppService, UsuarioAppService>();
             builder.Services.AddScoped<IContaBancariaAppService, ContaBancariaAppService>();
+
+            // configure encryption options
+            builder.Services.Configure<CryptoOptions>(builder.Configuration.GetSection("Crypto"));
 
             var jwtSection = builder.Configuration.GetSection("Jwt");
             builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/ControleFinanceiro.Api/appsettings.json
+++ b/ControleFinanceiro.Api/appsettings.json
@@ -6,5 +6,8 @@
     "Key": "SuperSecretKey",
     "Issuer": "ControleFinanceiroApi",
     "Audience": "ControleFinanceiroApiUsers"
+  },
+  "Crypto": {
+    "Key": "0123456789abcdef0123456789abcdef"
   }
 }

--- a/ControleFinanceiro.Infrastructure/ControleFinanceiro.Infrastructure.csproj
+++ b/ControleFinanceiro.Infrastructure/ControleFinanceiro.Infrastructure.csproj
@@ -8,5 +8,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ControleFinanceiro.Domain\ControleFinanceiro.Domain.csproj" />
+    <ProjectReference Include="..\ControleFinanceiro.Shared\ControleFinanceiro.Shared.csproj" />
   </ItemGroup>
 </Project>

--- a/ControleFinanceiro.Infrastructure/Repositories/CartaoRepository.cs
+++ b/ControleFinanceiro.Infrastructure/Repositories/CartaoRepository.cs
@@ -5,24 +5,26 @@ using ControleFinanceiro.Domain.Entities;
 using ControleFinanceiro.Domain.Repositories;
 using ControleFinanceiro.Infrastructure.Data;
 using ControleFinanceiro.Shared.Utils;
+using Microsoft.Extensions.Options;
 
 namespace ControleFinanceiro.Infrastructure.Repositories
 {
     public class CartaoRepository : ICartaoRepository
     {
         private readonly FinanceiroDbContext _context;
-
-        public CartaoRepository(FinanceiroDbContext context)
+        private readonly CryptoOptions _cryptoOptions;
+        public CartaoRepository(FinanceiroDbContext context, IOptions<CryptoOptions> options)
         {
             _context = context;
+            _cryptoOptions = options.Value;
         }
 
         public void Add(Cartao cartao)
         {
-            cartao.Numero = Crypto.Encrypt(cartao.Numero, Constants.EncryptionKey);
+            cartao.Numero = Crypto.Encrypt(cartao.Numero, _cryptoOptions.Key);
             _context.Cartoes.Add(cartao);
             _context.SaveChanges();
-            cartao.Numero = Crypto.Decrypt(cartao.Numero, Constants.EncryptionKey);
+            cartao.Numero = Crypto.Decrypt(cartao.Numero, _cryptoOptions.Key);
         }
 
         public void Delete(Guid id)
@@ -40,7 +42,7 @@ namespace ControleFinanceiro.Infrastructure.Repositories
             var cartao = _context.Cartoes.Find(id);
             if (cartao != null)
             {
-                cartao.Numero = Crypto.Decrypt(cartao.Numero, Constants.EncryptionKey);
+                cartao.Numero = Crypto.Decrypt(cartao.Numero, _cryptoOptions.Key);
             }
             return cartao;
         }
@@ -50,7 +52,7 @@ namespace ControleFinanceiro.Infrastructure.Repositories
             var cartoes = _context.Cartoes.Where(c => c.PessoaId == pessoaId).ToList();
             foreach (var c in cartoes)
             {
-                c.Numero = Crypto.Decrypt(c.Numero, Constants.EncryptionKey);
+                c.Numero = Crypto.Decrypt(c.Numero, _cryptoOptions.Key);
             }
             return cartoes;
         }
@@ -60,17 +62,17 @@ namespace ControleFinanceiro.Infrastructure.Repositories
             var cartoes = _context.Cartoes.Where(c => c.DataValidade <= data).ToList();
             foreach (var c in cartoes)
             {
-                c.Numero = Crypto.Decrypt(c.Numero, Constants.EncryptionKey);
+                c.Numero = Crypto.Decrypt(c.Numero, _cryptoOptions.Key);
             }
             return cartoes;
         }
 
         public void Update(Cartao cartao)
         {
-            cartao.Numero = Crypto.Encrypt(cartao.Numero, Constants.EncryptionKey);
+            cartao.Numero = Crypto.Encrypt(cartao.Numero, _cryptoOptions.Key);
             _context.Cartoes.Update(cartao);
             _context.SaveChanges();
-            cartao.Numero = Crypto.Decrypt(cartao.Numero, Constants.EncryptionKey);
+            cartao.Numero = Crypto.Decrypt(cartao.Numero, _cryptoOptions.Key);
         }
     }
 }

--- a/ControleFinanceiro.Infrastructure/Repositories/ContaBancariaRepository.cs
+++ b/ControleFinanceiro.Infrastructure/Repositories/ContaBancariaRepository.cs
@@ -5,24 +5,26 @@ using ControleFinanceiro.Domain.Entities;
 using ControleFinanceiro.Domain.Repositories;
 using ControleFinanceiro.Infrastructure.Data;
 using ControleFinanceiro.Shared.Utils;
+using Microsoft.Extensions.Options;
 
 namespace ControleFinanceiro.Infrastructure.Repositories
 {
     public class ContaBancariaRepository : IContaBancariaRepository
     {
         private readonly FinanceiroDbContext _context;
-
-        public ContaBancariaRepository(FinanceiroDbContext context)
+        private readonly CryptoOptions _cryptoOptions;
+        public ContaBancariaRepository(FinanceiroDbContext context, IOptions<CryptoOptions> options)
         {
             _context = context;
+            _cryptoOptions = options.Value;
         }
 
         public void Add(ContaBancaria conta)
         {
-            conta.Numero = Crypto.Encrypt(conta.Numero, Constants.EncryptionKey);
+            conta.Numero = Crypto.Encrypt(conta.Numero, _cryptoOptions.Key);
             _context.ContasBancarias.Add(conta);
             _context.SaveChanges();
-            conta.Numero = Crypto.Decrypt(conta.Numero, Constants.EncryptionKey);
+            conta.Numero = Crypto.Decrypt(conta.Numero, _cryptoOptions.Key);
         }
 
         public void Delete(Guid id)
@@ -40,7 +42,7 @@ namespace ControleFinanceiro.Infrastructure.Repositories
             var conta = _context.ContasBancarias.Find(id);
             if (conta != null)
             {
-                conta.Numero = Crypto.Decrypt(conta.Numero, Constants.EncryptionKey);
+                conta.Numero = Crypto.Decrypt(conta.Numero, _cryptoOptions.Key);
             }
             return conta;
         }
@@ -50,17 +52,17 @@ namespace ControleFinanceiro.Infrastructure.Repositories
             var contas = _context.ContasBancarias.Where(c => c.PessoaId == pessoaId).ToList();
             foreach (var c in contas)
             {
-                c.Numero = Crypto.Decrypt(c.Numero, Constants.EncryptionKey);
+                c.Numero = Crypto.Decrypt(c.Numero, _cryptoOptions.Key);
             }
             return contas;
         }
 
         public void Update(ContaBancaria conta)
         {
-            conta.Numero = Crypto.Encrypt(conta.Numero, Constants.EncryptionKey);
+            conta.Numero = Crypto.Encrypt(conta.Numero, _cryptoOptions.Key);
             _context.ContasBancarias.Update(conta);
             _context.SaveChanges();
-            conta.Numero = Crypto.Decrypt(conta.Numero, Constants.EncryptionKey);
+            conta.Numero = Crypto.Decrypt(conta.Numero, _cryptoOptions.Key);
         }
     }
 }

--- a/ControleFinanceiro.Infrastructure/Repositories/PessoaRepository.cs
+++ b/ControleFinanceiro.Infrastructure/Repositories/PessoaRepository.cs
@@ -5,24 +5,26 @@ using ControleFinanceiro.Domain.Entities;
 using ControleFinanceiro.Domain.Repositories;
 using ControleFinanceiro.Infrastructure.Data;
 using ControleFinanceiro.Shared.Utils;
+using Microsoft.Extensions.Options;
 
 namespace ControleFinanceiro.Infrastructure.Repositories
 {
     public class PessoaRepository : IPessoaRepository
     {
         private readonly FinanceiroDbContext _context;
-
-        public PessoaRepository(FinanceiroDbContext context)
+        private readonly CryptoOptions _cryptoOptions;
+        public PessoaRepository(FinanceiroDbContext context, IOptions<CryptoOptions> options)
         {
             _context = context;
+            _cryptoOptions = options.Value;
         }
 
         public void Add(Pessoa pessoa)
         {
-            pessoa.Documento = Crypto.Encrypt(pessoa.Documento, Constants.EncryptionKey);
+            pessoa.Documento = Crypto.Encrypt(pessoa.Documento, _cryptoOptions.Key);
             _context.Pessoas.Add(pessoa);
             _context.SaveChanges();
-            pessoa.Documento = Crypto.Decrypt(pessoa.Documento, Constants.EncryptionKey);
+            pessoa.Documento = Crypto.Decrypt(pessoa.Documento, _cryptoOptions.Key);
         }
 
         public void Delete(Guid id)
@@ -40,18 +42,18 @@ namespace ControleFinanceiro.Infrastructure.Repositories
             var pessoas = _context.Pessoas.Where(p => p.Ativo).ToList();
             foreach (var p in pessoas)
             {
-                p.Documento = Crypto.Decrypt(p.Documento, Constants.EncryptionKey);
+                p.Documento = Crypto.Decrypt(p.Documento, _cryptoOptions.Key);
             }
             return pessoas;
         }
 
         public Pessoa GetByDocumento(string documento)
         {
-            var enc = Crypto.Encrypt(documento, Constants.EncryptionKey);
+            var enc = Crypto.Encrypt(documento, _cryptoOptions.Key);
             var pessoa = _context.Pessoas.FirstOrDefault(p => p.Documento == enc && p.Ativo);
             if (pessoa != null)
             {
-                pessoa.Documento = Crypto.Decrypt(pessoa.Documento, Constants.EncryptionKey);
+                pessoa.Documento = Crypto.Decrypt(pessoa.Documento, _cryptoOptions.Key);
             }
             return pessoa;
         }
@@ -61,7 +63,7 @@ namespace ControleFinanceiro.Infrastructure.Repositories
             var pessoa = _context.Pessoas.Find(id);
             if (pessoa != null && pessoa.Ativo)
             {
-                pessoa.Documento = Crypto.Decrypt(pessoa.Documento, Constants.EncryptionKey);
+                pessoa.Documento = Crypto.Decrypt(pessoa.Documento, _cryptoOptions.Key);
                 return pessoa;
             }
             return null;
@@ -72,17 +74,17 @@ namespace ControleFinanceiro.Infrastructure.Repositories
             var pessoas = _context.Pessoas.Where(p => p.Nome.Contains(nome) && p.Ativo).ToList();
             foreach (var p in pessoas)
             {
-                p.Documento = Crypto.Decrypt(p.Documento, Constants.EncryptionKey);
+                p.Documento = Crypto.Decrypt(p.Documento, _cryptoOptions.Key);
             }
             return pessoas;
         }
 
         public void Update(Pessoa pessoa)
         {
-            pessoa.Documento = Crypto.Encrypt(pessoa.Documento, Constants.EncryptionKey);
+            pessoa.Documento = Crypto.Encrypt(pessoa.Documento, _cryptoOptions.Key);
             _context.Pessoas.Update(pessoa);
             _context.SaveChanges();
-            pessoa.Documento = Crypto.Decrypt(pessoa.Documento, Constants.EncryptionKey);
+            pessoa.Documento = Crypto.Decrypt(pessoa.Documento, _cryptoOptions.Key);
         }
     }
 }

--- a/ControleFinanceiro.Shared/Utils/Constants.cs
+++ b/ControleFinanceiro.Shared/Utils/Constants.cs
@@ -3,8 +3,5 @@ namespace ControleFinanceiro.Shared.Utils
     public static class Constants
     {
         public const string ApiVersion = "1.0";
-
-        // Key used for AES encryption of sensitive data
-        public const string EncryptionKey = "0123456789abcdef0123456789abcdef";
     }
 }

--- a/ControleFinanceiro.Shared/Utils/CryptoOptions.cs
+++ b/ControleFinanceiro.Shared/Utils/CryptoOptions.cs
@@ -1,0 +1,7 @@
+namespace ControleFinanceiro.Shared.Utils
+{
+    public class CryptoOptions
+    {
+        public string Key { get; set; } = string.Empty;
+    }
+}

--- a/ControleFinanceiro.Tests/Services/ContaBancariaCartaoEncryptionTests.cs
+++ b/ControleFinanceiro.Tests/Services/ContaBancariaCartaoEncryptionTests.cs
@@ -11,13 +11,14 @@ namespace ControleFinanceiro.Tests.Services
 {
     public class ContaBancariaCartaoEncryptionTests
     {
+        private const string Key = "0123456789abcdef0123456789abcdef";
         private class InMemoryContaBancariaRepository : IContaBancariaRepository
         {
             public readonly List<ContaBancaria> Stored = new();
 
             public void Add(ContaBancaria conta)
             {
-                var enc = Crypto.Encrypt(conta.Numero, Constants.EncryptionKey);
+                var enc = Crypto.Encrypt(conta.Numero, Key);
                 Stored.Add(new ContaBancaria
                 {
                     Id = conta.Id,
@@ -26,7 +27,7 @@ namespace ControleFinanceiro.Tests.Services
                     Agencia = conta.Agencia,
                     Numero = enc
                 });
-                conta.Numero = Crypto.Decrypt(enc, Constants.EncryptionKey);
+                conta.Numero = Crypto.Decrypt(enc, Key);
             }
 
             public void Update(ContaBancaria conta)
@@ -50,7 +51,7 @@ namespace ControleFinanceiro.Tests.Services
                     PessoaId = entity.PessoaId,
                     Banco = entity.Banco,
                     Agencia = entity.Agencia,
-                    Numero = Crypto.Decrypt(entity.Numero, Constants.EncryptionKey)
+                    Numero = Crypto.Decrypt(entity.Numero, Key)
                 };
             }
 
@@ -64,7 +65,7 @@ namespace ControleFinanceiro.Tests.Services
                         PessoaId = e.PessoaId,
                         Banco = e.Banco,
                         Agencia = e.Agencia,
-                        Numero = Crypto.Decrypt(e.Numero, Constants.EncryptionKey)
+                        Numero = Crypto.Decrypt(e.Numero, Key)
                     });
             }
         }
@@ -75,7 +76,7 @@ namespace ControleFinanceiro.Tests.Services
 
             public void Add(Cartao cartao)
             {
-                var enc = Crypto.Encrypt(cartao.Numero, Constants.EncryptionKey);
+                var enc = Crypto.Encrypt(cartao.Numero, Key);
                 Stored.Add(new Cartao
                 {
                     Id = cartao.Id,
@@ -88,7 +89,7 @@ namespace ControleFinanceiro.Tests.Services
                     Numero = enc,
                     NumeroFinal = cartao.NumeroFinal
                 });
-                cartao.Numero = Crypto.Decrypt(enc, Constants.EncryptionKey);
+                cartao.Numero = Crypto.Decrypt(enc, Key);
             }
 
             public void Update(Cartao cartao)
@@ -115,7 +116,7 @@ namespace ControleFinanceiro.Tests.Services
                     DataValidade = e.DataValidade,
                     CodigoSeguranca = e.CodigoSeguranca,
                     Limite = e.Limite,
-                    Numero = Crypto.Decrypt(e.Numero, Constants.EncryptionKey),
+                    Numero = Crypto.Decrypt(e.Numero, Key),
                     NumeroFinal = e.NumeroFinal
                 };
             }
@@ -132,7 +133,7 @@ namespace ControleFinanceiro.Tests.Services
                         DataValidade = e.DataValidade,
                         CodigoSeguranca = e.CodigoSeguranca,
                         Limite = e.Limite,
-                        Numero = Crypto.Decrypt(e.Numero, Constants.EncryptionKey),
+                        Numero = Crypto.Decrypt(e.Numero, Key),
                         NumeroFinal = e.NumeroFinal
                     });
             }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Todos os projetos da solução estão configurados para o *Target Framework* `ne
    dotnet ef database update -s ControleFinanceiro.Api/ControleFinanceiro.Api.csproj -p ControleFinanceiro.Infrastructure/ControleFinanceiro.Infrastructure.csproj
    ```
 
+## Configurando a chave de criptografia
+
+Defina um valor seguro para `Crypto:Key` em `appsettings.json` ou por meio da variável de ambiente `Crypto__Key`. Essa chave é utilizada para criptografar dados sensíveis armazenados no banco de dados.
+
+
 ## Build e execução da API
 
 Restaure as dependências, compile a solução e execute o projeto da API:


### PR DESCRIPTION
## Summary
- store encryption key in `appsettings.json`
- load key via `CryptoOptions` and inject into repositories
- update tests to use local key constant
- document how to configure the key in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cbab04cc4832c8f474e0e0ea9d58e