### PR TITLE
Add .NET test instructions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,5 +13,6 @@ jobs:
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '8.0.x'
+    - run: dotnet tool restore
     - run: dotnet restore
     - run: dotnet test --no-build --verbosity normal

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ Use `/api/relatorios/movimentacoes` para retornar o total de entradas e saídas 
 e `/api/relatorios/contas` para consultar o montante de contas a pagar e a receber.
 Também é possível informar o parâmetro `tipo` em `/api/relatorios/movimentacoes/tipo` para filtrar por tipo de movimentação.
 
+## Executando os testes
+
+Instale o [SDK do .NET](https://dotnet.microsoft.com/download) 8.0 ou superior e verifique se o comando `dotnet` está disponível no terminal. Caso seja a primeira vez que você clona o repositório, restaure as ferramentas locais:
+
+```bash
+dotnet tool restore
+```
+
+Depois disso, execute todos os testes unitários da solução:
+
+```bash
+dotnet test
+```
+
 ## Contribuindo
 
 Sinta-se à vontade para fazer fork deste repositório, abrir issues e enviar pull requests. Relatos de bugs e ideias de funcionalidades são bem-vindos!


### PR DESCRIPTION
## Summary
- show how to restore local tools and run tests in the README
- restore tools in CI before running `dotnet test`

## Testing
- `dotnet tool restore` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cbceaabe4832c8ffcd63374eead1c