### PR TITLE
Add manual settlement functionality

### DIFF
--- a/ControleFinanceiro.Api/Controllers/ContasPagarController.cs
+++ b/ControleFinanceiro.Api/Controllers/ContasPagarController.cs
@@ -62,6 +62,18 @@ namespace ControleFinanceiro.Api.Controllers
             return NoContent();
         }
 
+        [HttpPut("{id}/pagar")]
+        public IActionResult MarcarComoPaga(Guid id, [FromBody] DateTime? data)
+        {
+            var conta = _service.GetById(id);
+            if (conta == null)
+                return NotFound();
+            conta.EstaPaga = true;
+            conta.DataPagamento = data ?? DateTime.Now;
+            _service.Update(conta);
+            return NoContent();
+        }
+
         [HttpDelete("{id}")]
         public IActionResult Delete(Guid id)
         {

--- a/ControleFinanceiro.Api/Controllers/ContasReceberController.cs
+++ b/ControleFinanceiro.Api/Controllers/ContasReceberController.cs
@@ -62,6 +62,18 @@ namespace ControleFinanceiro.Api.Controllers
             return NoContent();
         }
 
+        [HttpPut("{id}/receber")]
+        public IActionResult MarcarComoRecebida(Guid id, [FromBody] DateTime? data)
+        {
+            var conta = _service.GetById(id);
+            if (conta == null)
+                return NotFound();
+            conta.EstaRecebido = true;
+            conta.DataRecebimento = data ?? DateTime.Now;
+            _service.Update(conta);
+            return NoContent();
+        }
+
         [HttpDelete("{id}")]
         public IActionResult Delete(Guid id)
         {

--- a/ControleFinanceiro.Tests/Services/ContaPagarAppServiceTests.cs
+++ b/ControleFinanceiro.Tests/Services/ContaPagarAppServiceTests.cs
@@ -53,5 +53,52 @@ namespace ControleFinanceiro.Tests.Services
             Assert.Throws<InvalidOperationException>(() => service.Update(conta));
             repo.Verify(r => r.Update(It.IsAny<ContaPagar>()), Times.Never);
         }
+
+        [Fact]
+        public void Update_DeNaoPagaParaPaga_DeveGerarMovimentacao()
+        {
+            var repo = new Mock<IContaPagarRepository>();
+            var formaRepo = new Mock<IFormaPagamentoRepository>();
+            var movRepo = new Mock<IMovimentacaoFinanceiraRepository>();
+            var service = new ContaPagarAppService(repo.Object, formaRepo.Object, movRepo.Object);
+
+            var id = Guid.NewGuid();
+            var existente = new ContaPagar
+            {
+                Id = id,
+                PessoaId = Guid.NewGuid(),
+                Descricao = "Teste",
+                Responsavel = "Eu",
+                ValorTotal = 50m,
+                NumeroParcelas = 1,
+                Valor = 50m,
+                DataVencimento = DateTime.Today,
+                EstaPaga = false
+            };
+            repo.Setup(r => r.GetById(id)).Returns(existente);
+
+            var atualizar = new ContaPagar
+            {
+                Id = id,
+                PessoaId = existente.PessoaId,
+                Descricao = existente.Descricao,
+                Responsavel = existente.Responsavel,
+                ValorTotal = existente.ValorTotal,
+                NumeroParcelas = existente.NumeroParcelas,
+                Valor = existente.Valor,
+                DataVencimento = existente.DataVencimento,
+                EstaPaga = true,
+                DataPagamento = DateTime.Today
+            };
+
+            service.Update(atualizar);
+
+            movRepo.Verify(r => r.Add(It.Is<MovimentacaoFinanceira>(m =>
+                m.Tipo == TipoMovimentacao.Saida &&
+                m.Valor == atualizar.Valor &&
+                m.Data == atualizar.DataPagamento &&
+                m.PessoaId == atualizar.PessoaId)), Times.Once);
+            repo.Verify(r => r.Update(atualizar), Times.Once);
+        }
     }
 }

--- a/ControleFinanceiro.Tests/Services/ContaReceberAppServiceTests.cs
+++ b/ControleFinanceiro.Tests/Services/ContaReceberAppServiceTests.cs
@@ -1,0 +1,59 @@
+using System;
+using Moq;
+using Xunit;
+using ControleFinanceiro.Application.Services;
+using ControleFinanceiro.Domain.Entities;
+using ControleFinanceiro.Domain.Repositories;
+
+namespace ControleFinanceiro.Tests.Services
+{
+    public class ContaReceberAppServiceTests
+    {
+        [Fact]
+        public void Update_DeNaoRecebidaParaRecebida_DeveGerarMovimentacao()
+        {
+            var repo = new Mock<IContaReceberRepository>();
+            var formaRepo = new Mock<IFormaPagamentoRepository>();
+            var movRepo = new Mock<IMovimentacaoFinanceiraRepository>();
+            var service = new ContaReceberAppService(repo.Object, formaRepo.Object, movRepo.Object);
+
+            var id = Guid.NewGuid();
+            var existente = new ContaReceber
+            {
+                Id = id,
+                PessoaId = Guid.NewGuid(),
+                Descricao = "Teste",
+                Responsavel = "Eu",
+                ValorTotal = 80m,
+                NumeroParcelas = 1,
+                Valor = 80m,
+                DataVencimento = DateTime.Today,
+                EstaRecebido = false
+            };
+            repo.Setup(r => r.GetById(id)).Returns(existente);
+
+            var atualizar = new ContaReceber
+            {
+                Id = id,
+                PessoaId = existente.PessoaId,
+                Descricao = existente.Descricao,
+                Responsavel = existente.Responsavel,
+                ValorTotal = existente.ValorTotal,
+                NumeroParcelas = existente.NumeroParcelas,
+                Valor = existente.Valor,
+                DataVencimento = existente.DataVencimento,
+                EstaRecebido = true,
+                DataRecebimento = DateTime.Today
+            };
+
+            service.Update(atualizar);
+
+            movRepo.Verify(r => r.Add(It.Is<MovimentacaoFinanceira>(m =>
+                m.Tipo == TipoMovimentacao.Entrada &&
+                m.Valor == atualizar.Valor &&
+                m.Data == atualizar.DataRecebimento &&
+                m.PessoaId == atualizar.PessoaId)), Times.Once);
+            repo.Verify(r => r.Update(atualizar), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create financial movement when settling contas on update
- expose endpoints to mark contas as paid/received
- test manual settlement logic for contas pagar/receber

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cbf63a8bc832cb9ed3c64cb12c10f