### PR TITLE
Remove unused Transactions migration

### DIFF
--- a/ControleFinanceiro.Infrastructure/Data/Migrations/20250801010000_AddUsuariosAndTransactions.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/20250801010000_AddUsuariosAndTransactions.cs
@@ -24,46 +24,16 @@ namespace ControleFinanceiro.Infrastructure.Data.Migrations
                     table.PrimaryKey("PK_Usuarios", x => x.Id);
                 });
 
-            migrationBuilder.CreateTable(
-                name: "Transactions",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    PessoaId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    Tipo = table.Column<int>(type: "int", nullable: false),
-                    Valor = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
-                    Data = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    Descricao = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_Transactions", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_Transactions_Pessoas_PessoaId",
-                        column: x => x.PessoaId,
-                        principalTable: "Pessoas",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
             migrationBuilder.CreateIndex(
                 name: "IX_Usuarios_Email",
                 table: "Usuarios",
                 column: "Email",
                 unique: true);
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Transactions_PessoaId",
-                table: "Transactions",
-                column: "PessoaId");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(
-                name: "Transactions");
-
             migrationBuilder.DropTable(
                 name: "Usuarios");
         }

--- a/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
@@ -277,34 +277,6 @@ namespace ControleFinanceiro.Infrastructure.Data.Migrations
                 b.ToTable("Usuarios");
             });
 
-            modelBuilder.Entity("ControleFinanceiro.Domain.Entities.Transaction", b =>
-            {
-                b.Property<Guid>("Id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
-
-                b.Property<DateTime>("Data")
-                    .HasColumnType("datetime2");
-
-                b.Property<string>("Descricao")
-                    .HasMaxLength(200)
-                    .HasColumnType("nvarchar(200)");
-
-                b.Property<Guid>("PessoaId")
-                    .HasColumnType("uniqueidentifier");
-
-                b.Property<int>("Tipo")
-                    .HasColumnType("int");
-
-                b.Property<decimal>("Valor")
-                    .HasColumnType("decimal(18,2)");
-
-                b.HasKey("Id");
-
-                b.HasIndex("PessoaId");
-
-                b.ToTable("Transactions");
-            });
 #pragma warning restore 612, 618
         }
     }


### PR DESCRIPTION
## Summary
- prune Transaction table from the `AddUsuariosAndTransactions` migration
- update the EF Core snapshot to match

## Testing
- `dotnet tool restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cc0a0b61c832c8cef07b40f89c43b