### PR TITLE
Add conta refs to movimentacoes

### DIFF
--- a/ControleFinanceiro.Application/Services/ContaPagarAppService.cs
+++ b/ControleFinanceiro.Application/Services/ContaPagarAppService.cs
@@ -58,7 +58,8 @@ namespace ControleFinanceiro.Application.Services
                             Tipo = TipoMovimentacao.Saida,
                             Valor = parcela.Valor,
                             Data = parcela.DataPagamento.Value,
-                            Descricao = parcela.Descricao
+                            Descricao = parcela.Descricao,
+                            ContaPagarId = parcela.Id
                         };
                         _movimentacaoRepository.Add(mov);
                     }
@@ -94,7 +95,8 @@ namespace ControleFinanceiro.Application.Services
                     Tipo = TipoMovimentacao.Saida,
                     Valor = contaPagar.Valor,
                     Data = contaPagar.DataPagamento.Value,
-                    Descricao = contaPagar.Descricao
+                    Descricao = contaPagar.Descricao,
+                    ContaPagarId = contaPagar.Id
                 };
                 _movimentacaoRepository.Add(mov);
             }

--- a/ControleFinanceiro.Application/Services/ContaReceberAppService.cs
+++ b/ControleFinanceiro.Application/Services/ContaReceberAppService.cs
@@ -58,7 +58,8 @@ namespace ControleFinanceiro.Application.Services
                             Tipo = TipoMovimentacao.Entrada,
                             Valor = parcela.Valor,
                             Data = parcela.DataRecebimento.Value,
-                            Descricao = parcela.Descricao
+                            Descricao = parcela.Descricao,
+                            ContaReceberId = parcela.Id
                         };
                         _movimentacaoRepository.Add(mov);
                     }
@@ -94,7 +95,8 @@ namespace ControleFinanceiro.Application.Services
                     Tipo = TipoMovimentacao.Entrada,
                     Valor = contaReceber.Valor,
                     Data = contaReceber.DataRecebimento.Value,
-                    Descricao = contaReceber.Descricao
+                    Descricao = contaReceber.Descricao,
+                    ContaReceberId = contaReceber.Id
                 };
                 _movimentacaoRepository.Add(mov);
             }

--- a/ControleFinanceiro.Domain/Entities/MovimentacaoFinanceira.cs
+++ b/ControleFinanceiro.Domain/Entities/MovimentacaoFinanceira.cs
@@ -22,7 +22,15 @@ namespace ControleFinanceiro.Domain.Entities
 
         public Guid? ContaBancariaId { get; set; }
 
+        public Guid? ContaPagarId { get; set; }
+
+        public Guid? ContaReceberId { get; set; }
+
         public ContaBancaria ContaBancaria { get; set; }
+
+        public ContaPagar ContaPagar { get; set; }
+
+        public ContaReceber ContaReceber { get; set; }
 
         public Pessoa Pessoa { get; set; }
     }

--- a/ControleFinanceiro.Infrastructure/Data/FinanceiroDbContext.cs
+++ b/ControleFinanceiro.Infrastructure/Data/FinanceiroDbContext.cs
@@ -66,6 +66,16 @@ namespace ControleFinanceiro.Infrastructure.Data
                 .WithMany()
                 .HasForeignKey(m => m.ContaBancariaId);
 
+            modelBuilder.Entity<MovimentacaoFinanceira>()
+                .HasOne(m => m.ContaPagar)
+                .WithMany()
+                .HasForeignKey(m => m.ContaPagarId);
+
+            modelBuilder.Entity<MovimentacaoFinanceira>()
+                .HasOne(m => m.ContaReceber)
+                .WithMany()
+                .HasForeignKey(m => m.ContaReceberId);
+
             modelBuilder.Entity<ContaBancaria>()
                 .HasOne(c => c.Pessoa)
                 .WithMany(p => p.ContasBancarias)

--- a/ControleFinanceiro.Infrastructure/Data/Migrations/20250801021000_AddContaIdsToMovimentacaoFinanceira.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/20250801021000_AddContaIdsToMovimentacaoFinanceira.cs
@@ -1,0 +1,74 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ControleFinanceiro.Infrastructure.Data.Migrations
+{
+    public partial class AddContaIdsToMovimentacaoFinanceira : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ContaPagarId",
+                table: "MovimentacoesFinanceiras",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ContaReceberId",
+                table: "MovimentacoesFinanceiras",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MovimentacoesFinanceiras_ContaPagarId",
+                table: "MovimentacoesFinanceiras",
+                column: "ContaPagarId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MovimentacoesFinanceiras_ContaReceberId",
+                table: "MovimentacoesFinanceiras",
+                column: "ContaReceberId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MovimentacoesFinanceiras_ContasPagar_ContaPagarId",
+                table: "MovimentacoesFinanceiras",
+                column: "ContaPagarId",
+                principalTable: "ContasPagar",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MovimentacoesFinanceiras_ContasReceber_ContaReceberId",
+                table: "MovimentacoesFinanceiras",
+                column: "ContaReceberId",
+                principalTable: "ContasReceber",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MovimentacoesFinanceiras_ContasPagar_ContaPagarId",
+                table: "MovimentacoesFinanceiras");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MovimentacoesFinanceiras_ContasReceber_ContaReceberId",
+                table: "MovimentacoesFinanceiras");
+
+            migrationBuilder.DropIndex(
+                name: "IX_MovimentacoesFinanceiras_ContaPagarId",
+                table: "MovimentacoesFinanceiras");
+
+            migrationBuilder.DropIndex(
+                name: "IX_MovimentacoesFinanceiras_ContaReceberId",
+                table: "MovimentacoesFinanceiras");
+
+            migrationBuilder.DropColumn(
+                name: "ContaPagarId",
+                table: "MovimentacoesFinanceiras");
+
+            migrationBuilder.DropColumn(
+                name: "ContaReceberId",
+                table: "MovimentacoesFinanceiras");
+        }
+    }
+}

--- a/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
@@ -173,6 +173,12 @@ namespace ControleFinanceiro.Infrastructure.Data.Migrations
                 b.Property<Guid?>("ContaBancariaId")
                     .HasColumnType("uniqueidentifier");
 
+                b.Property<Guid?>("ContaPagarId")
+                    .HasColumnType("uniqueidentifier");
+
+                b.Property<Guid?>("ContaReceberId")
+                    .HasColumnType("uniqueidentifier");
+
                 b.Property<Guid>("PessoaId")
                     .HasColumnType("uniqueidentifier");
 
@@ -185,6 +191,8 @@ namespace ControleFinanceiro.Infrastructure.Data.Migrations
                 b.HasKey("Id");
 
                 b.HasIndex("ContaBancariaId");
+                b.HasIndex("ContaPagarId");
+                b.HasIndex("ContaReceberId");
                 b.HasIndex("PessoaId");
 
                 b.ToTable("MovimentacoesFinanceiras");


### PR DESCRIPTION
## Summary
- link movimentacoes to contas pagar/receber
- update DbContext and EF migrations
- include conta ids when generating movimentacoes automatically

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*
- `apt-get update` *(fails: internet is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_688cc466c8b8832c860b73f5b2d9e1bc