### PR TITLE
Add CPF/CNPJ validation

### DIFF
--- a/ControleFinanceiro.Application/ControleFinanceiro.Application.csproj
+++ b/ControleFinanceiro.Application/ControleFinanceiro.Application.csproj
@@ -5,5 +5,6 @@
   <ItemGroup>
     <ProjectReference Include="..\ControleFinanceiro.Domain\ControleFinanceiro.Domain.csproj" />
     <ProjectReference Include="..\ControleFinanceiro.Infrastructure\ControleFinanceiro.Infrastructure.csproj" />
+    <ProjectReference Include="..\ControleFinanceiro.Shared\ControleFinanceiro.Shared.csproj" />
   </ItemGroup>
 </Project>

--- a/ControleFinanceiro.Application/Services/PessoaAppService.cs
+++ b/ControleFinanceiro.Application/Services/PessoaAppService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using ControleFinanceiro.Domain.Entities;
 using ControleFinanceiro.Domain.Repositories;
+using ControleFinanceiro.Shared.Utils;
 
 namespace ControleFinanceiro.Application.Services
 {
@@ -16,6 +17,10 @@ namespace ControleFinanceiro.Application.Services
 
         public void Create(Pessoa pessoa)
         {
+            if (!DocumentoValidator.IsValid(pessoa.Documento))
+            {
+                throw new InvalidOperationException("Documento inválido.");
+            }
             if (_pessoaRepository.GetByDocumento(pessoa.Documento) != null)
             {
                 throw new InvalidOperationException("Documento já cadastrado.");
@@ -27,6 +32,11 @@ namespace ControleFinanceiro.Application.Services
 
         public void Update(Pessoa pessoa)
         {
+            if (!DocumentoValidator.IsValid(pessoa.Documento))
+            {
+                throw new InvalidOperationException("Documento inválido.");
+            }
+
             var existente = _pessoaRepository.GetById(pessoa.Id);
             if (existente == null)
             {

--- a/ControleFinanceiro.Shared/Utils/DocumentoValidator.cs
+++ b/ControleFinanceiro.Shared/Utils/DocumentoValidator.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+
+namespace ControleFinanceiro.Shared.Utils
+{
+    public static class DocumentoValidator
+    {
+        public static bool IsValid(string documento)
+        {
+            if (string.IsNullOrWhiteSpace(documento)) return false;
+            var digits = new string(documento.Where(char.IsDigit).ToArray());
+            return digits.Length switch
+            {
+                11 => IsValidCpf(digits),
+                14 => IsValidCnpj(digits),
+                _ => false
+            };
+        }
+
+        private static bool IsValidCpf(string cpf)
+        {
+            if (cpf.Length != 11 || cpf.All(c => c == cpf[0])) return false;
+            int[] mult1 = {10,9,8,7,6,5,4,3,2};
+            int[] mult2 = {11,10,9,8,7,6,5,4,3,2};
+            int sum = 0;
+            for (int i = 0; i < 9; i++)
+                sum += (cpf[i] - '0') * mult1[i];
+            int rem = sum % 11;
+            int dig1 = rem < 2 ? 0 : 11 - rem;
+            sum = 0;
+            for (int i = 0; i < 10; i++)
+                sum += ((i == 9 ? dig1 : cpf[i] - '0')) * mult2[i];
+            rem = sum % 11;
+            int dig2 = rem < 2 ? 0 : 11 - rem;
+            return cpf.EndsWith($"{dig1}{dig2}");
+        }
+
+        private static bool IsValidCnpj(string cnpj)
+        {
+            if (cnpj.Length != 14 || cnpj.All(c => c == cnpj[0])) return false;
+            int[] mult1 = {5,4,3,2,9,8,7,6,5,4,3,2};
+            int[] mult2 = {6,5,4,3,2,9,8,7,6,5,4,3,2};
+            int sum = 0;
+            for (int i = 0; i < 12; i++)
+                sum += (cnpj[i] - '0') * mult1[i];
+            int rem = sum % 11;
+            int dig1 = rem < 2 ? 0 : 11 - rem;
+            sum = 0;
+            for (int i = 0; i < 13; i++)
+                sum += ((i == 12 ? dig1 : cnpj[i] - '0')) * mult2[i];
+            rem = sum % 11;
+            int dig2 = rem < 2 ? 0 : 11 - rem;
+            return cnpj.EndsWith($"{dig1}{dig2}");
+        }
+    }
+}

--- a/ControleFinanceiro.Tests/Services/PessoaAppServiceTests.cs
+++ b/ControleFinanceiro.Tests/Services/PessoaAppServiceTests.cs
@@ -15,7 +15,7 @@ namespace ControleFinanceiro.Tests.Services
             var repo = new Mock<IPessoaRepository>();
             repo.Setup(r => r.GetByDocumento(It.IsAny<string>())).Returns((Pessoa)null);
             var service = new PessoaAppService(repo.Object);
-            var pessoa = new Pessoa { Id = Guid.NewGuid(), Nome = "Teste", Email = "t@t.com", Documento = "123" };
+            var pessoa = new Pessoa { Id = Guid.NewGuid(), Nome = "Teste", Email = "t@t.com", Documento = "12345678909" };
 
             service.Create(pessoa);
 
@@ -27,9 +27,21 @@ namespace ControleFinanceiro.Tests.Services
         public void Create_DuplicateDocumento_ThrowsInvalidOperationException()
         {
             var repo = new Mock<IPessoaRepository>();
-            repo.Setup(r => r.GetByDocumento("123")).Returns(new Pessoa());
+            repo.Setup(r => r.GetByDocumento("12345678909")).Returns(new Pessoa());
             var service = new PessoaAppService(repo.Object);
-            var pessoa = new Pessoa { Id = Guid.NewGuid(), Nome = "Teste", Email = "t@t.com", Documento = "123" };
+            var pessoa = new Pessoa { Id = Guid.NewGuid(), Nome = "Teste", Email = "t@t.com", Documento = "12345678909" };
+
+            Assert.Throws<InvalidOperationException>(() => service.Create(pessoa));
+            repo.Verify(r => r.Add(It.IsAny<Pessoa>()), Times.Never);
+        }
+
+        [Fact]
+        public void Create_InvalidDocumento_ThrowsInvalidOperationException()
+        {
+            var repo = new Mock<IPessoaRepository>();
+            repo.Setup(r => r.GetByDocumento(It.IsAny<string>())).Returns((Pessoa)null);
+            var service = new PessoaAppService(repo.Object);
+            var pessoa = new Pessoa { Id = Guid.NewGuid(), Nome = "Teste", Email = "t@t.com", Documento = "12345678900" };
 
             Assert.Throws<InvalidOperationException>(() => service.Create(pessoa));
             repo.Verify(r => r.Add(It.IsAny<Pessoa>()), Times.Never);
@@ -41,7 +53,7 @@ namespace ControleFinanceiro.Tests.Services
             var repo = new Mock<IPessoaRepository>();
             repo.Setup(r => r.GetById(It.IsAny<Guid>())).Returns((Pessoa)null);
             var service = new PessoaAppService(repo.Object);
-            var pessoa = new Pessoa { Id = Guid.NewGuid(), Nome = "Teste", Email = "t@t.com", Documento = "123" };
+            var pessoa = new Pessoa { Id = Guid.NewGuid(), Nome = "Teste", Email = "t@t.com", Documento = "12345678909" };
 
             Assert.Throws<InvalidOperationException>(() => service.Update(pessoa));
         }
@@ -52,9 +64,22 @@ namespace ControleFinanceiro.Tests.Services
             var repo = new Mock<IPessoaRepository>();
             var id = Guid.NewGuid();
             repo.Setup(r => r.GetById(id)).Returns(new Pessoa { Id = id });
-            repo.Setup(r => r.GetByDocumento("456")).Returns(new Pessoa { Id = Guid.NewGuid() });
+            repo.Setup(r => r.GetByDocumento("11444777000161")).Returns(new Pessoa { Id = Guid.NewGuid() });
             var service = new PessoaAppService(repo.Object);
-            var pessoa = new Pessoa { Id = id, Nome = "Teste", Email = "t@t.com", Documento = "456" };
+            var pessoa = new Pessoa { Id = id, Nome = "Teste", Email = "t@t.com", Documento = "11444777000161" };
+
+            Assert.Throws<InvalidOperationException>(() => service.Update(pessoa));
+            repo.Verify(r => r.Update(It.IsAny<Pessoa>()), Times.Never);
+        }
+
+        [Fact]
+        public void Update_InvalidDocumento_ThrowsInvalidOperationException()
+        {
+            var repo = new Mock<IPessoaRepository>();
+            var id = Guid.NewGuid();
+            repo.Setup(r => r.GetById(id)).Returns(new Pessoa { Id = id });
+            var service = new PessoaAppService(repo.Object);
+            var pessoa = new Pessoa { Id = id, Nome = "Teste", Email = "t@t.com", Documento = "11444777000162" };
 
             Assert.Throws<InvalidOperationException>(() => service.Update(pessoa));
             repo.Verify(r => r.Update(It.IsAny<Pessoa>()), Times.Never);


### PR DESCRIPTION
## Summary
- enforce CPF/CNPJ validation before creating or updating `Pessoa`
- add utility `DocumentoValidator` for document checking
- reference shared project from application layer
- adjust and expand `PessoaAppServiceTests` with invalid document scenarios

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cc5e90910832c927308ad34a2dbf5