### PR TITLE
Add migration to extend column sizes

### DIFF
--- a/ControleFinanceiro.Infrastructure/Data/Migrations/20250801023000_UpdateSensitiveFieldSizes.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/20250801023000_UpdateSensitiveFieldSizes.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ControleFinanceiro.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateSensitiveFieldSizes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Documento",
+                table: "Pessoas",
+                type: "nvarchar(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(14)",
+                oldMaxLength: 14);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Numero",
+                table: "Cartoes",
+                type: "nvarchar(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(16)",
+                oldMaxLength: 16);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Numero",
+                table: "ContasBancarias",
+                type: "nvarchar(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(20)",
+                oldMaxLength: 20);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Documento",
+                table: "Pessoas",
+                type: "nvarchar(14)",
+                maxLength: 14,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Numero",
+                table: "Cartoes",
+                type: "nvarchar(16)",
+                maxLength: 16,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Numero",
+                table: "ContasBancarias",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(512)",
+                oldMaxLength: 512);
+        }
+    }
+}

--- a/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
+++ b/ControleFinanceiro.Infrastructure/Data/Migrations/FinanceiroDbContextModelSnapshot.cs
@@ -35,8 +35,8 @@ namespace ControleFinanceiro.Infrastructure.Data.Migrations
 
                 b.Property<string>("Numero")
                     .IsRequired()
-                    .HasMaxLength(16)
-                    .HasColumnType("nvarchar(16)");
+                    .HasMaxLength(512)
+                    .HasColumnType("nvarchar(512)");
 
                 b.Property<string>("Bandeira")
                     .IsRequired()
@@ -78,8 +78,8 @@ namespace ControleFinanceiro.Infrastructure.Data.Migrations
 
                 b.Property<string>("Numero")
                     .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnType("nvarchar(20)");
+                    .HasMaxLength(512)
+                    .HasColumnType("nvarchar(512)");
 
                 b.Property<Guid>("PessoaId")
                     .HasColumnType("uniqueidentifier");
@@ -263,8 +263,8 @@ namespace ControleFinanceiro.Infrastructure.Data.Migrations
 
                 b.Property<string>("Documento")
                     .IsRequired()
-                    .HasMaxLength(14)
-                    .HasColumnType("nvarchar(14)");
+                    .HasMaxLength(512)
+                    .HasColumnType("nvarchar(512)");
 
                 b.Property<bool>("Ativo")
                     .HasColumnType("bit")

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Todos os projetos da solução estão configurados para o *Target Framework* `ne
    dotnet ef migrations add AddUsuarios -s ControleFinanceiro.Api/ControleFinanceiro.Api.csproj -p ControleFinanceiro.Infrastructure/ControleFinanceiro.Infrastructure.csproj
    dotnet ef database update -s ControleFinanceiro.Api/ControleFinanceiro.Api.csproj -p ControleFinanceiro.Infrastructure/ControleFinanceiro.Infrastructure.csproj
    ```
+5. Após aplicar a migração `UpdateSensitiveFieldSizes`, execute novamente:
+   ```bash
+   dotnet ef database update -s ControleFinanceiro.Api/ControleFinanceiro.Api.csproj -p ControleFinanceiro.Infrastructure/ControleFinanceiro.Infrastructure.csproj
+   ```
 
 ## Configurando a chave de criptografia
 


### PR DESCRIPTION
## Summary
- create `UpdateSensitiveFieldSizes` EF Core migration
- adjust model snapshot for new column sizes
- note database update step in README

## Testing
- `dotnet test` *(fails: Azure.Core 1.25.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cf9df0040832c93e7e64a03d45e13